### PR TITLE
Set Profile Button To Current User instead of BK's Account

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -90,7 +90,7 @@ const Header = (props: HeaderProps) => {
               <DropdownMenuItem
                 onClick={() =>
                   window.open(
-                    "https://sso.gauchoracing.com/users/348220961155448833/edit",
+                    `https://sso.gauchoracing.com/users/${currentUser.id}/edit`,
                     "_blank",
                   )
                 }


### PR DESCRIPTION
Resolves #1

Changes the profile button from BK's account to the current users account

Follows the fix in https://github.com/Gaucho-Racing/gr-web-template/pull/2